### PR TITLE
Update sysmon_install.ps1

### DIFF
--- a/Windows_Sysmon/sysmon_install.ps1
+++ b/Windows_Sysmon/sysmon_install.ps1
@@ -2,7 +2,7 @@ $sysinternals_repo = 'download.sysinternals.com'
 $sysinternals_downloadlink = 'https://download.sysinternals.com/files/SysinternalsSuite.zip'
 $sysinternals_folder = 'C:\Program Files\sysinternals'
 $sysinternals_zip = 'SysinternalsSuite.zip'
-$sysmonconfig_downloadlink = 'https://raw.githubusercontent.com/olafhartong/sysmon-modular/master/sysmonconfig.xml'
+$sysmonconfig_downloadlink = 'https://github.com/SwiftOnSecurity/sysmon-config/blob/master/sysmonconfig-export.xml'
 $sysmonconfig_file = 'sysmonconfig-export.xml'
 
 [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12


### PR DESCRIPTION
modified sysmonconfig_downloadlink to match Readme Document. Fixes the issue to stop Sysmon64 with great difficulty in order to apply Readme recommended xml configuration.